### PR TITLE
refactor: refactor to expose Envelope interface

### DIFF
--- a/signature/algorithm.go
+++ b/signature/algorithm.go
@@ -68,3 +68,28 @@ func ExtractKeySpec(signingCert *x509.Certificate) (KeySpec, error) {
 		Msg: "invalid public key type",
 	}
 }
+
+// SignatureAlgorithm returns the signing algorithm associated with the KeySpec.
+func (k KeySpec) SignatureAlgorithm() Algorithm {
+	switch k.Type {
+	case KeyTypeEC:
+		switch k.Size {
+		case 256:
+			return AlgorithmES256
+		case 384:
+			return AlgorithmES384
+		case 521:
+			return AlgorithmES512
+		}
+	case KeyTypeRSA:
+		switch k.Size {
+		case 2048:
+			return AlgorithmPS256
+		case 3072:
+			return AlgorithmPS384
+		case 4096:
+			return AlgorithmPS512
+		}
+	}
+	return 0
+}

--- a/signature/algorithm_test.go
+++ b/signature/algorithm_test.go
@@ -101,3 +101,77 @@ func TestExtractKeySpec(t *testing.T) {
 		})
 	}
 }
+
+func TestSignatureAlgorithm(t *testing.T) {
+	tests := []struct {
+		name    string
+		keySpec KeySpec
+		expect  Algorithm
+	}{
+		{
+			name: "EC 256",
+			keySpec: KeySpec{
+				Type: KeyTypeEC,
+				Size: 256,
+			},
+			expect: AlgorithmES256,
+		},
+		{
+			name: "EC 384",
+			keySpec: KeySpec{
+				Type: KeyTypeEC,
+				Size: 384,
+			},
+			expect: AlgorithmES384,
+		},
+		{
+			name: "EC 521",
+			keySpec: KeySpec{
+				Type: KeyTypeEC,
+				Size: 521,
+			},
+			expect: AlgorithmES512,
+		},
+		{
+			name: "RSA 2048",
+			keySpec: KeySpec{
+				Type: KeyTypeRSA,
+				Size: 2048,
+			},
+			expect: AlgorithmPS256,
+		},
+		{
+			name: "RSA 3072",
+			keySpec: KeySpec{
+				Type: KeyTypeRSA,
+				Size: 3072,
+			},
+			expect: AlgorithmPS384,
+		},
+		{
+			name: "RSA 4096",
+			keySpec: KeySpec{
+				Type: KeyTypeRSA,
+				Size: 4096,
+			},
+			expect: AlgorithmPS512,
+		},
+		{
+			name: "Unsupported key spec",
+			keySpec: KeySpec{
+				Type: 0,
+				Size: 0,
+			},
+			expect: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alg := tt.keySpec.SignatureAlgorithm()
+			if alg != tt.expect {
+				t.Errorf("unexpected signature algorithm: %v, expect: %v", alg, tt.expect)
+			}
+		})
+	}
+}

--- a/signature/envelope.go
+++ b/signature/envelope.go
@@ -1,0 +1,96 @@
+// Package signature provides operations for types that implement
+// signature.Envelope or signature.Signer.
+//
+// An Envelope is a structure that creates and verifies a signature using the
+// specified signing algorithm with required validation. To register a new
+// envelope, call RegisterEnvelopeType first during the initialization.
+//
+// A Signer is a structure used to sign payload generated after signature
+// envelope created. The underlying signing logic is provided by the underlying
+// local crypto library or the external signing plugin.
+package signature
+
+import "fmt"
+
+// Envelope provides functions to basic functions to manipulate signatures.
+type Envelope interface {
+	// Sign generates and sign the envelope according to the sign request.
+	Sign(req *SignRequest) ([]byte, error)
+
+	// Verify verifies the envelope and returns its enclosed payload and signer
+	// info.
+	Verify() (*Payload, *SignerInfo, error)
+
+	// Payload returns the payload of the envelope.
+	// Payload is trusted only after the successful call to `Verify()`.
+	Payload() (*Payload, error)
+
+	// SignerInfo returns the signer information of the envelope.
+	// SignerInfo is trusted only after the successful call to `Verify()`.
+	SignerInfo() (*SignerInfo, error)
+}
+
+// NewEnvelopeFunc defines a function to create a new Envelope.
+type NewEnvelopeFunc func() Envelope
+
+// ParseEnvelopeFunc defines a function that takes envelope bytes to create
+// an Envelope.
+type ParseEnvelopeFunc func([]byte) (Envelope, error)
+
+// envelopeFunc wraps functions to create and parsenew envelopes.
+type envelopeFunc struct {
+	newFunc   NewEnvelopeFunc
+	parseFunc ParseEnvelopeFunc
+}
+
+// envelopeFuncs maps envelope media type to corresponding constructors and
+// parsers.
+var envelopeFuncs map[string]envelopeFunc
+
+// RegisterEnvelopeType registers newFunc and parseFunc for the given mediaType.
+// Those functions are intended to be called when creating a new envelope.
+// It will be called while inializing the built-in envelopes(JWS/COSE).
+func RegisterEnvelopeType(mediaType string, newFunc NewEnvelopeFunc, parseFunc ParseEnvelopeFunc) error {
+	if newFunc == nil || parseFunc == nil {
+		return fmt.Errorf("required functions not provided")
+	}
+	if envelopeFuncs == nil {
+		envelopeFuncs = make(map[string]envelopeFunc)
+	}
+
+	envelopeFuncs[mediaType] = envelopeFunc{
+		newFunc:   newFunc,
+		parseFunc: parseFunc,
+	}
+	return nil
+}
+
+// RegisteredEnvelopeTypes lists registered envelope media types.
+func RegisteredEnvelopeTypes() []string {
+	var types []string
+
+	for envelopeType := range envelopeFuncs {
+		types = append(types, envelopeType)
+	}
+
+	return types
+}
+
+// NewEnvelope generates an envelope of given media type.
+func NewEnvelope(mediaType string) (Envelope, error) {
+	envelopeFunc, ok := envelopeFuncs[mediaType]
+	if !ok {
+		return nil, &UnsupportedSignatureFormatError{MediaType: mediaType}
+	}
+	return envelopeFunc.newFunc(), nil
+}
+
+// ParseEnvelope generates an envelope by given envelope bytes with specified
+// media type.
+func ParseEnvelope(mediaType string, envelopeBytes []byte) (Envelope, error) {
+	envelopeFunc, ok := envelopeFuncs[mediaType]
+	if !ok {
+		return nil, &UnsupportedSignatureFormatError{MediaType: mediaType}
+	}
+	return envelopeFunc.parseFunc(envelopeBytes)
+}

--- a/signature/envelope_test.go
+++ b/signature/envelope_test.go
@@ -1,0 +1,199 @@
+package signature
+
+import (
+	"reflect"
+	"testing"
+)
+
+// mock an envelope that implements signature.Envelope.
+type testEnvelope struct {
+}
+
+// Sign implements Sign of signature.Envelope.
+func (e testEnvelope) Sign(req *SignRequest) ([]byte, error) {
+	return nil, nil
+}
+
+// Verify implements Verify of signature.Envelope.
+func (e testEnvelope) Verify() (*Payload, *SignerInfo, error) {
+	return nil, nil, nil
+}
+
+// Payload implements Payload of signature.Envelope.
+func (e testEnvelope) Payload() (*Payload, error) {
+	return nil, nil
+}
+
+// SignerInfo implements SignerInfo of signature.Envelope.
+func (e testEnvelope) SignerInfo() (*SignerInfo, error) {
+	return nil, nil
+}
+
+var (
+	testNewFunc = func() Envelope {
+		return testEnvelope{}
+	}
+	testParseFunc = func([]byte) (Envelope, error) {
+		return testEnvelope{}, nil
+	}
+)
+
+func TestRegisterEnvelopeType(t *testing.T) {
+	tests := []struct {
+		name      string
+		mediaType string
+		newFunc   NewEnvelopeFunc
+		parseFunc ParseEnvelopeFunc
+		expectErr bool
+	}{
+		{
+			name:      "nil newFunc",
+			mediaType: testMediaType,
+			newFunc:   nil,
+			parseFunc: testParseFunc,
+			expectErr: true,
+		},
+		{
+			name:      "nil newParseFunc",
+			mediaType: testMediaType,
+			newFunc:   testNewFunc,
+			parseFunc: nil,
+			expectErr: true,
+		},
+		{
+			name:      "valid funcs",
+			mediaType: testMediaType,
+			newFunc:   testNewFunc,
+			parseFunc: testParseFunc,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := RegisterEnvelopeType(tt.mediaType, tt.newFunc, tt.parseFunc)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
+			}
+		})
+	}
+}
+
+func TestRegisteredEnvelopeTypes(t *testing.T) {
+	tests := []struct {
+		name          string
+		envelopeFuncs map[string]envelopeFunc
+		expect        []string
+	}{
+		{
+			name:          "empty map",
+			envelopeFuncs: make(map[string]envelopeFunc),
+			expect:        nil,
+		},
+		{
+			name: "nonempty map",
+			envelopeFuncs: map[string]envelopeFunc{
+				testMediaType: {},
+			},
+			expect: []string{testMediaType},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envelopeFuncs = tt.envelopeFuncs
+			types := RegisteredEnvelopeTypes()
+
+			if !reflect.DeepEqual(types, tt.expect) {
+				t.Errorf("got types: %v, expect types: %v", types, tt.expect)
+			}
+		})
+	}
+}
+
+func TestNewEnvelope(t *testing.T) {
+	tests := []struct {
+		name          string
+		mediaType     string
+		envelopeFuncs map[string]envelopeFunc
+		expect        Envelope
+		expectErr     bool
+	}{
+		{
+			name:          "unsupported media type",
+			mediaType:     testMediaType,
+			envelopeFuncs: make(map[string]envelopeFunc),
+			expect:        nil,
+			expectErr:     true,
+		},
+		{
+			name:      "valid media type",
+			mediaType: testMediaType,
+			envelopeFuncs: map[string]envelopeFunc{
+				testMediaType: {
+					newFunc: testNewFunc,
+				},
+			},
+			expect:    testEnvelope{},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envelopeFuncs = tt.envelopeFuncs
+			envelope, err := NewEnvelope(tt.mediaType)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("got error: %v, expected error? %v", err, tt.expectErr)
+			}
+			if envelope != tt.expect {
+				t.Errorf("got envelope: %v, expected envelope? %v", envelope, tt.expect)
+			}
+		})
+	}
+}
+
+func TestParseEnvelope(t *testing.T) {
+	tests := []struct {
+		name          string
+		mediaType     string
+		envelopeFuncs map[string]envelopeFunc
+		expect        Envelope
+		expectErr     bool
+	}{
+		{
+			name:          "unsupported media type",
+			mediaType:     testMediaType,
+			envelopeFuncs: make(map[string]envelopeFunc),
+			expect:        nil,
+			expectErr:     true,
+		},
+		{
+			name:      "valid media type",
+			mediaType: testMediaType,
+			envelopeFuncs: map[string]envelopeFunc{
+				testMediaType: {
+					parseFunc: testParseFunc,
+				},
+			},
+			expect:    testEnvelope{},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envelopeFuncs = tt.envelopeFuncs
+			envelope, err := ParseEnvelope(tt.mediaType, nil)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("got error: %v, expected error? %v", err, tt.expectErr)
+			}
+			if envelope != tt.expect {
+				t.Errorf("got envelope: %v, expected envelope? %v", envelope, tt.expect)
+			}
+		})
+	}
+}

--- a/signature/internal/base/envelope.go
+++ b/signature/internal/base/envelope.go
@@ -1,0 +1,235 @@
+package base
+
+import (
+	"crypto/x509"
+	"fmt"
+	"time"
+
+	"github.com/notaryproject/notation-core-go/signature"
+	nx509 "github.com/notaryproject/notation-core-go/x509"
+)
+
+// Envelope represents a general envelope wrapping a raw signature and envelope
+// in specific format.
+// Envelope manipulates the common validation shared by internal envelopes.
+type Envelope struct {
+	signature.Envelope        // internal envelope in a specific format(e.g. Cose, JWS)
+	Raw                []byte // raw signature
+}
+
+// Sign generates signature in terms of given SignRequest.
+//
+// Reference: https://github.com/notaryproject/notaryproject/blob/main/signing-and-verification-workflow.md#signing-steps
+func (e *Envelope) Sign(req *signature.SignRequest) ([]byte, error) {
+	// Canonicalize request.
+	req.SigningTime = req.SigningTime.Truncate(time.Second)
+	req.Expiry = req.Expiry.Truncate(time.Second)
+	err := validateSignRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := e.Envelope.Sign(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// validate certificate chain
+	signerInfo, err := e.Envelope.SignerInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateCertificateChain(
+		signerInfo.CertificateChain,
+		signerInfo.SignedAttributes.SigningTime,
+		signerInfo.SignatureAlgorithm,
+	); err != nil {
+		return nil, err
+	}
+
+	e.Raw = raw
+	return e.Raw, nil
+}
+
+// Verify performs integrity and other signature specification related
+// validations.
+// It returns the payload to be signed and SignerInfo object containing the
+// information about the signature.
+//
+// Reference: https://github.com/notaryproject/notaryproject/blob/main/trust-store-trust-policy-specification.md#steps
+func (e *Envelope) Verify() (*signature.Payload, *signature.SignerInfo, error) {
+	// validation before the core verify process.
+	if len(e.Raw) == 0 {
+		return nil, nil, &signature.MalformedSignatureError{}
+	}
+
+	// core verify process.
+	payload, signerInfo, err := e.Envelope.Verify()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// validation after the core verify process.
+	if err = validatePayload(payload); err != nil {
+		return nil, nil, err
+	}
+
+	if err = validateSignerInfo(signerInfo); err != nil {
+		return nil, nil, err
+	}
+
+	return payload, signerInfo, nil
+}
+
+// Payload returns the validated payload to be signed.
+func (e *Envelope) Payload() (*signature.Payload, error) {
+	if len(e.Raw) == 0 {
+		return nil, &signature.MalformedSignatureError{Msg: "raw signature is empty"}
+	}
+	payload, err := e.Envelope.Payload()
+	if err != nil {
+		return nil, err
+	}
+
+	if err = validatePayload(payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+// SignerInfo returns validated information about the signature envelope.
+func (e *Envelope) SignerInfo() (*signature.SignerInfo, error) {
+	if len(e.Raw) == 0 {
+		return nil, &signature.MalformedSignatureError{Msg: "raw signature is empty"}
+	}
+
+	signerInfo, err := e.Envelope.SignerInfo()
+	if err != nil {
+		return nil, &signature.MalformedSignatureError{
+			Msg: fmt.Sprintf("signature envelope format is malformed. error: %s", err),
+		}
+	}
+
+	if err := validateSignerInfo(signerInfo); err != nil {
+		return nil, err
+	}
+
+	return signerInfo, nil
+}
+
+// validatePayload performs validation of the payload.
+func (e *Envelope) validatePayload() error {
+	payload, err := e.Envelope.Payload()
+	if err != nil {
+		return err
+	}
+
+	return validatePayload(payload)
+}
+
+// validateSignRequest performs basic set of validations on SignRequest struct.
+func validateSignRequest(req *signature.SignRequest) error {
+	if err := validatePayload(&req.Payload); err != nil {
+		return err
+	}
+
+	if err := validateSigningTime(req.SigningTime, req.Expiry); err != nil {
+		return err
+	}
+
+	if req.Signer == nil {
+		return &signature.MalformedSignatureError{Msg: "signer is nil"}
+	}
+
+	_, err := req.Signer.KeySpec()
+	return err
+}
+
+// validateSignerInfo performs basic set of validations on SignerInfo struct.
+func validateSignerInfo(info *signature.SignerInfo) error {
+	if len(info.Signature) == 0 {
+		return &signature.MalformedSignatureError{Msg: "signature not present or is empty"}
+	}
+
+	if info.SignatureAlgorithm == 0 {
+		return &signature.MalformedSignatureError{Msg: "SignatureAlgorithm is not present"}
+	}
+
+	signingTime := info.SignedAttributes.SigningTime
+	if err := validateSigningTime(signingTime, info.SignedAttributes.Expiry); err != nil {
+		return err
+	}
+
+	return validateCertificateChain(
+		info.CertificateChain,
+		signingTime,
+		info.SignatureAlgorithm,
+	)
+}
+
+// validateSigningTime checks that signing time is within the valid range of
+// time duration.
+func validateSigningTime(signingTime, expireTime time.Time) error {
+	if signingTime.IsZero() {
+		return &signature.MalformedSignatureError{Msg: "signing-time not present"}
+	}
+
+	if !expireTime.IsZero() && (expireTime.Before(signingTime) || expireTime.Equal(signingTime)) {
+		return &signature.MalformedSignatureError{Msg: "expiry cannot be equal or before the signing time"}
+	}
+	return nil
+}
+
+// validatePayload performs validation of the payload.
+func validatePayload(payload *signature.Payload) error {
+	switch payload.ContentType {
+	case signature.MediaTypePayloadV1:
+		if len(payload.Content) == 0 {
+			return &signature.MalformedSignatureError{Msg: "content not present"}
+		}
+	default:
+		return &signature.MalformedSignatureError{
+			Msg: fmt.Sprintf("payload content type: {%s} not supported", payload.ContentType),
+		}
+	}
+
+	return nil
+}
+
+// validateCertificateChain performs the validation of the certificate chain.
+func validateCertificateChain(certChain []*x509.Certificate, signTime time.Time, expectedAlg signature.Algorithm) error {
+	if len(certChain) == 0 {
+		return &signature.MalformedSignatureError{Msg: "certificate-chain not present or is empty"}
+	}
+
+	err := nx509.ValidateCodeSigningCertChain(certChain, signTime)
+	if err != nil {
+		return &signature.MalformedSignatureError{
+			Msg: fmt.Sprintf("certificate-chain is invalid, %s", err),
+		}
+	}
+
+	signingAlg, err := getSignatureAlgorithm(certChain[0])
+	if err != nil {
+		return &signature.MalformedSignatureError{Msg: err.Error()}
+	}
+	if signingAlg != expectedAlg {
+		return &signature.MalformedSignatureError{
+			Msg: fmt.Sprintf("mismatch between signature algorithm derived from signing certificate (%v) and signing algorithm specified (%vs)", signingAlg, expectedAlg),
+		}
+	}
+
+	return nil
+}
+
+// getSignatureAlgorithm picks up a recommended signing algorithm for given
+// certificate.
+func getSignatureAlgorithm(signingCert *x509.Certificate) (signature.Algorithm, error) {
+	keySpec, err := signature.ExtractKeySpec(signingCert)
+	if err != nil {
+		return 0, err
+	}
+
+	return keySpec.SignatureAlgorithm(), nil
+}

--- a/signature/internal/base/envelope_test.go
+++ b/signature/internal/base/envelope_test.go
@@ -1,0 +1,786 @@
+package base
+
+import (
+	"crypto/x509"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/notaryproject/notation-core-go/signature"
+	"github.com/notaryproject/notation-core-go/testhelper"
+)
+
+var (
+	errMsg              = "error msg"
+	invalidSigningAgent = "test/1"
+	validSigningAgent   = "test/0"
+	invalidContentType  = "text/plain"
+	validContentType    = "application/vnd.cncf.notary.payload.v1+json"
+	validContent        = "test content"
+	validBytes          = []byte(validContent)
+	time08_02           time.Time
+	time08_03           time.Time
+	timeLayout          = "2006-01-02"
+	validSignerInfo     = &signature.SignerInfo{
+		Signature:          validBytes,
+		SignatureAlgorithm: signature.AlgorithmPS384,
+		SignedAttributes: signature.SignedAttributes{
+			SigningTime: testhelper.GetRSALeafCertificate().Cert.NotBefore,
+			Expiry:      testhelper.GetECLeafCertificate().Cert.NotAfter,
+		},
+		CertificateChain: []*x509.Certificate{
+			testhelper.GetRSALeafCertificate().Cert,
+			testhelper.GetRSARootCertificate().Cert,
+		},
+	}
+	validPayload = &signature.Payload{
+		ContentType: validContentType,
+		Content:     validBytes,
+	}
+	validReq = &signature.SignRequest{
+		Payload: signature.Payload{
+			ContentType: validContentType,
+			Content:     validBytes,
+		},
+		SigningTime: testhelper.GetRSALeafCertificate().Cert.NotBefore,
+		Expiry:      testhelper.GetRSALeafCertificate().Cert.NotAfter,
+		Signer: &mockSigner{
+			keySpec: signature.KeySpec{
+				Type: signature.KeyTypeRSA,
+				Size: 3072,
+			},
+			certs: []*x509.Certificate{
+				testhelper.GetRSALeafCertificate().Cert,
+				testhelper.GetRSARootCertificate().Cert,
+			},
+		},
+		SigningAgent: validSigningAgent,
+	}
+	signReq1 = &signature.SignRequest{
+		Payload: signature.Payload{
+			ContentType: validContentType,
+			Content:     validBytes,
+		},
+		SigningTime: testhelper.GetRSALeafCertificate().Cert.NotBefore,
+		Expiry:      testhelper.GetRSALeafCertificate().Cert.NotAfter,
+		Signer: &mockSigner{
+			keySpec: signature.KeySpec{
+				Type: signature.KeyTypeRSA,
+				Size: 3072,
+			},
+			certs: []*x509.Certificate{
+				testhelper.GetRSALeafCertificate().Cert,
+				testhelper.GetRSARootCertificate().Cert,
+			},
+		},
+		SigningAgent: invalidSigningAgent,
+	}
+)
+
+func init() {
+	time08_02, _ = time.Parse(timeLayout, "2020-08-02")
+	time08_03, _ = time.Parse(timeLayout, "2020-08-03")
+}
+
+// Mock an internal envelope that implements signature.Envelope.
+type mockEnvelope struct {
+	payload            *signature.Payload
+	verifiedPayload    *signature.Payload
+	signerInfo         *signature.SignerInfo
+	verifiedSignerInfo *signature.SignerInfo
+	failVerify         bool
+}
+
+// Sign implements Sign of signature.Envelope.
+func (e mockEnvelope) Sign(req *signature.SignRequest) ([]byte, error) {
+	switch req.SigningAgent {
+	case invalidSigningAgent:
+		return nil, errors.New(errMsg)
+	case validSigningAgent:
+		return validBytes, nil
+	}
+	return nil, nil
+}
+
+// Verify implements Verify of signature.Envelope.
+func (e mockEnvelope) Verify() (*signature.Payload, *signature.SignerInfo, error) {
+	if e.failVerify {
+		return nil, nil, errors.New(errMsg)
+	}
+	return e.verifiedPayload, e.verifiedSignerInfo, nil
+}
+
+// Payload implements Payload of signature.Envelope.
+func (e mockEnvelope) Payload() (*signature.Payload, error) {
+	if e.payload == nil {
+		return nil, errors.New(errMsg)
+	}
+	return e.payload, nil
+}
+
+// SignerInfo implements SignerInfo of signature.Envelope.
+func (e mockEnvelope) SignerInfo() (*signature.SignerInfo, error) {
+	if e.signerInfo == nil {
+		return nil, errors.New(errMsg)
+	}
+	return e.signerInfo, nil
+}
+
+// Mock a signer implements signature.Signer.
+type mockSigner struct {
+	certs   []*x509.Certificate
+	keySpec signature.KeySpec
+}
+
+// CertificateChain implements CertificateChain of signature.Signer.
+func (s *mockSigner) CertificateChain() ([]*x509.Certificate, error) {
+	if len(s.certs) == 0 {
+		return nil, errors.New(errMsg)
+	}
+	return s.certs, nil
+}
+
+// Sign implements Sign of signature.Signer.
+func (s *mockSigner) Sign(payload []byte) ([]byte, []*x509.Certificate, error) {
+	return nil, nil, nil
+}
+
+// KeySpec implements KeySpec of signature.Signer.
+func (s *mockSigner) KeySpec() (signature.KeySpec, error) {
+	var emptyKeySpec signature.KeySpec
+	if s.keySpec == emptyKeySpec {
+		return s.keySpec, errors.New(errMsg)
+	}
+	return s.keySpec, nil
+}
+
+func TestSign(t *testing.T) {
+	tests := []struct {
+		name      string
+		req       *signature.SignRequest
+		env       *Envelope
+		expect    []byte
+		expectErr bool
+	}{
+		{
+			name: "invalid request",
+			req: &signature.SignRequest{
+				SigningTime: time08_02,
+				Expiry:      time08_02,
+			},
+			env: &Envelope{
+				Raw:      nil,
+				Envelope: mockEnvelope{},
+			},
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "internal envelope fails to sign",
+			req:  signReq1,
+			env: &Envelope{
+				Raw:      nil,
+				Envelope: mockEnvelope{},
+			},
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "internal envelope fails to get signerInfo",
+			req:  validReq,
+			env: &Envelope{
+				Raw:      nil,
+				Envelope: mockEnvelope{},
+			},
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "invalid certificate chain",
+			req:  validReq,
+			env: &Envelope{
+				Raw: nil,
+				Envelope: mockEnvelope{
+					signerInfo: &signature.SignerInfo{},
+				},
+			},
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "successfully signed",
+			req:  validReq,
+			env: &Envelope{
+				Raw: validBytes,
+				Envelope: &mockEnvelope{
+					signerInfo: validSignerInfo,
+				},
+			},
+			expect:    validBytes,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sig, err := tt.env.Sign(tt.req)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
+			}
+			if !reflect.DeepEqual(sig, tt.expect) {
+				t.Errorf("expect %+v, got %+v", tt.expect, sig)
+			}
+		})
+	}
+}
+
+func TestVerify(t *testing.T) {
+	tests := []struct {
+		name             string
+		env              *Envelope
+		expectPayload    *signature.Payload
+		expectSignerInfo *signature.SignerInfo
+		expectErr        bool
+	}{
+		{
+			name:             "empty raw",
+			env:              &Envelope{},
+			expectPayload:    nil,
+			expectSignerInfo: nil,
+			expectErr:        true,
+		},
+		{
+			name: "err returned by internal envelope",
+			env: &Envelope{
+				Raw: validBytes,
+				Envelope: &mockEnvelope{
+					failVerify: true,
+					payload:    validPayload,
+				},
+			},
+			expectPayload:    nil,
+			expectSignerInfo: nil,
+			expectErr:        true,
+		},
+		{
+			name: "payload validation failed after internal envelope verfication",
+			env: &Envelope{
+				Raw: validBytes,
+				Envelope: &mockEnvelope{
+					failVerify:      false,
+					payload:         validPayload,
+					verifiedPayload: &signature.Payload{},
+				},
+			},
+			expectPayload:    nil,
+			expectSignerInfo: nil,
+			expectErr:        true,
+		},
+		{
+			name: "signerInfo validation failed after internal envelope verfication",
+			env: &Envelope{
+				Raw: validBytes,
+				Envelope: &mockEnvelope{
+					failVerify:         false,
+					payload:            validPayload,
+					verifiedPayload:    validPayload,
+					verifiedSignerInfo: &signature.SignerInfo{},
+				},
+			},
+			expectPayload:    nil,
+			expectSignerInfo: nil,
+			expectErr:        true,
+		},
+		{
+			name: "verify successfully",
+			env: &Envelope{
+				Raw: validBytes,
+				Envelope: &mockEnvelope{
+					failVerify:         false,
+					payload:            validPayload,
+					verifiedPayload:    validPayload,
+					verifiedSignerInfo: validSignerInfo,
+				},
+			},
+			expectPayload:    validPayload,
+			expectSignerInfo: validSignerInfo,
+			expectErr:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, signerInfo, err := tt.env.Verify()
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
+			}
+			if !reflect.DeepEqual(payload, tt.expectPayload) {
+				t.Errorf("expect payload: %+v, got %+v", tt.expectPayload, payload)
+			}
+			if !reflect.DeepEqual(signerInfo, tt.expectSignerInfo) {
+				t.Errorf("expect signerInfo: %+v, got %+v", tt.expectSignerInfo, signerInfo)
+			}
+		})
+	}
+}
+
+func TestPayload(t *testing.T) {
+	tests := []struct {
+		name      string
+		env       *Envelope
+		expect    *signature.Payload
+		expectErr bool
+	}{
+		{
+			name:      "empty raw",
+			env:       &Envelope{},
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "err returned by internal envelope",
+			env: &Envelope{
+				Raw:      validBytes,
+				Envelope: &mockEnvelope{},
+			},
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "invalid payload",
+			env: &Envelope{
+				Raw: validBytes,
+				Envelope: &mockEnvelope{
+					payload: &signature.Payload{
+						ContentType: invalidContentType,
+					},
+				},
+			},
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "valid payload",
+			env: &Envelope{
+				Raw: validBytes,
+				Envelope: &mockEnvelope{
+					payload: validPayload,
+				},
+			},
+			expect:    validPayload,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, err := tt.env.Payload()
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
+			}
+			if !reflect.DeepEqual(payload, tt.expect) {
+				t.Errorf("expect %+v, got %+v", tt.expect, payload)
+			}
+		})
+	}
+}
+
+func TestSignerInfo(t *testing.T) {
+	tests := []struct {
+		name      string
+		env       *Envelope
+		expect    *signature.SignerInfo
+		expectErr bool
+	}{
+		{
+			name:      "empty raw",
+			env:       &Envelope{},
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "err returned by internal envelope",
+			env: &Envelope{
+				Raw:      validBytes,
+				Envelope: &mockEnvelope{},
+			},
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "invalid signerInfo",
+			env: &Envelope{
+				Raw: validBytes,
+				Envelope: &mockEnvelope{
+					signerInfo: &signature.SignerInfo{},
+				},
+			},
+			expect:    nil,
+			expectErr: true,
+		},
+		{
+			name: "valid signerInfo",
+			env: &Envelope{
+				Raw: validBytes,
+				Envelope: &mockEnvelope{
+					signerInfo: validSignerInfo,
+				},
+			},
+			expect:    validSignerInfo,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signerInfo, err := tt.env.SignerInfo()
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
+			}
+			if !reflect.DeepEqual(signerInfo, tt.expect) {
+				t.Errorf("expect %+v, got %+v", tt.expect, signerInfo)
+			}
+		})
+	}
+}
+
+func TestEnvelopeValidatePayload(t *testing.T) {
+	tests := []struct {
+		name      string
+		env       *Envelope
+		expectErr bool
+	}{
+		{
+			name: "err returned by internal payload call",
+			env: &Envelope{
+				Envelope: mockEnvelope{},
+			},
+			expectErr: true,
+		},
+		{
+			name: "valid payload",
+			env: &Envelope{
+				Envelope: mockEnvelope{
+					payload: &signature.Payload{
+						ContentType: validContentType,
+						Content:     validBytes,
+					},
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.env.validatePayload()
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
+			}
+		})
+	}
+}
+
+func TestValidateSignRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		req       *signature.SignRequest
+		expectErr bool
+	}{
+		{
+			name:      "invalid payload",
+			req:       &signature.SignRequest{},
+			expectErr: true,
+		},
+		{
+			name: "invalid signing time",
+			req: &signature.SignRequest{
+				Payload: signature.Payload{
+					ContentType: validContentType,
+					Content:     validBytes,
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "signer is nil",
+			req: &signature.SignRequest{
+				Payload: signature.Payload{
+					ContentType: validContentType,
+					Content:     validBytes,
+				},
+				SigningTime: time08_02,
+				Expiry:      time08_03,
+			},
+			expectErr: true,
+		},
+		{
+			name: "empty certificates",
+			req: &signature.SignRequest{
+				Payload: signature.Payload{
+					ContentType: validContentType,
+					Content:     validBytes,
+				},
+				SigningTime: time08_02,
+				Expiry:      time08_03,
+				Signer:      &mockSigner{},
+			},
+			expectErr: true,
+		},
+		{
+			name: "keySpec is empty",
+			req: &signature.SignRequest{
+				Payload: signature.Payload{
+					ContentType: validContentType,
+					Content:     validBytes,
+				},
+				SigningTime: time08_02,
+				Expiry:      time08_03,
+				Signer: &mockSigner{
+					certs: []*x509.Certificate{
+						testhelper.GetRSALeafCertificate().Cert,
+						testhelper.GetRSARootCertificate().Cert,
+					},
+					keySpec: signature.KeySpec{},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:      "valid request",
+			req:       validReq,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSignRequest(tt.req)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
+			}
+		})
+	}
+}
+
+func TestValidateSignerInfo(t *testing.T) {
+	tests := []struct {
+		name      string
+		info      *signature.SignerInfo
+		expectErr bool
+	}{
+		{
+			name:      "empty signature",
+			info:      &signature.SignerInfo{},
+			expectErr: true,
+		},
+		{
+			name: "missing signature algorithm",
+			info: &signature.SignerInfo{
+				Signature: validBytes,
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid signing time",
+			info: &signature.SignerInfo{
+				Signature:          validBytes,
+				SignatureAlgorithm: signature.AlgorithmPS256,
+			},
+			expectErr: true,
+		},
+		{
+			name:      "valid signerInfo",
+			info:      validSignerInfo,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSignerInfo(tt.info)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
+			}
+		})
+	}
+}
+
+func TestValidateSigningTime(t *testing.T) {
+	tests := []struct {
+		name        string
+		signingTime time.Time
+		expireTime  time.Time
+		expectErr   bool
+	}{
+		{
+			name:        "zero signing time",
+			signingTime: time.Time{},
+			expireTime:  time.Now(),
+			expectErr:   true,
+		},
+		{
+			name:        "no expire time",
+			signingTime: time.Now(),
+			expireTime:  time.Time{},
+			expectErr:   false,
+		},
+		{
+			name:        "expireTime set but invalid",
+			signingTime: time08_03,
+			expireTime:  time08_02,
+			expectErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSigningTime(tt.signingTime, tt.expireTime)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
+			}
+		})
+	}
+}
+
+func TestValidatePayload(t *testing.T) {
+	tests := []struct {
+		name      string
+		payload   *signature.Payload
+		expectErr bool
+	}{
+		{
+			name: "invalid payload content type",
+			payload: &signature.Payload{
+				ContentType: invalidContentType,
+			},
+			expectErr: true,
+		},
+		{
+			name: "payload content is empty",
+			payload: &signature.Payload{
+				ContentType: validContentType,
+				Content:     []byte{},
+			},
+			expectErr: true,
+		},
+		{
+			name:      "valid payload",
+			payload:   validPayload,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePayload(tt.payload)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
+			}
+		})
+	}
+}
+
+func TestValidateCertificateChain(t *testing.T) {
+	tests := []struct {
+		name      string
+		certs     []*x509.Certificate
+		signTime  time.Time
+		alg       signature.Algorithm
+		expectErr bool
+	}{
+		{
+			name:      "empty certs",
+			certs:     []*x509.Certificate{},
+			signTime:  time.Now(),
+			alg:       signature.AlgorithmES256,
+			expectErr: true,
+		},
+		{
+			name: "invalid certificates",
+			certs: []*x509.Certificate{
+				testhelper.GetECLeafCertificate().Cert,
+			},
+			signTime:  time.Now(),
+			alg:       signature.AlgorithmES256,
+			expectErr: true,
+		},
+		{
+			name: "unmacthed signing algorithm",
+			certs: []*x509.Certificate{
+				testhelper.GetRSALeafCertificate().Cert,
+				testhelper.GetRSARootCertificate().Cert,
+			},
+			signTime:  testhelper.GetRSALeafCertificate().Cert.NotBefore,
+			alg:       signature.AlgorithmPS256,
+			expectErr: true,
+		},
+		{
+			name: "valid certificate chain",
+			certs: []*x509.Certificate{
+				testhelper.GetRSALeafCertificate().Cert,
+				testhelper.GetRSARootCertificate().Cert,
+			},
+			signTime:  testhelper.GetRSALeafCertificate().Cert.NotBefore,
+			alg:       signature.AlgorithmPS384,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCertificateChain(tt.certs, tt.signTime, tt.alg)
+
+			if (err != nil) != tt.expectErr {
+				if (err != nil) != tt.expectErr {
+					t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
+				}
+			}
+		})
+	}
+}
+
+func TestGetSignatureAlgorithm(t *testing.T) {
+	tests := []struct {
+		name      string
+		cert      *x509.Certificate
+		expect    signature.Algorithm
+		expectErr bool
+	}{
+		{
+			name:      "unsupported cert",
+			cert:      testhelper.GetUnsupportedCertificate().Cert,
+			expect:    0,
+			expectErr: true,
+		},
+		{
+			name:      "valid cert",
+			cert:      testhelper.GetRSALeafCertificate().Cert,
+			expect:    signature.AlgorithmPS384,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alg, err := getSignatureAlgorithm(tt.cert)
+
+			if (err != nil) != tt.expectErr {
+				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
+			}
+			if !reflect.DeepEqual(alg, tt.expect) {
+				t.Errorf("expect %+v, got %+v", tt.expect, alg)
+			}
+		})
+	}
+}

--- a/signature/internal/base/envelope_test.go
+++ b/signature/internal/base/envelope_test.go
@@ -716,7 +716,7 @@ func TestValidateCertificateChain(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "unmacthed signing algorithm",
+			name: "unmatched signing algorithm",
 			certs: []*x509.Certificate{
 				testhelper.GetRSALeafCertificate().Cert,
 				testhelper.GetRSARootCertificate().Cert,
@@ -742,9 +742,7 @@ func TestValidateCertificateChain(t *testing.T) {
 			err := validateCertificateChain(tt.certs, tt.signTime, tt.alg)
 
 			if (err != nil) != tt.expectErr {
-				if (err != nil) != tt.expectErr {
-					t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
-				}
+				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
 			}
 		})
 	}

--- a/signature/types.go
+++ b/signature/types.go
@@ -95,6 +95,32 @@ type Payload struct {
 	Content []byte
 }
 
+// SignRequest is used to generate Signature.
+type SignRequest struct {
+	// Payload is the payload to be signed.
+	Payload Payload
+
+	// Signer is the signer used to sign the digest.
+	Signer Signer
+
+	// SigningTime is the time at which the signature was generated.
+	SigningTime time.Time
+
+	// Expiry provides a “best by use” time for the artifact.
+	Expiry time.Time
+
+	// ExtendedSignedAttributes is additional signed attributes in the
+	// signature envelope.
+	ExtendedSignedAttributes []Attribute
+
+	// SigningAgent provides the identifier of the software (e.g. Notation)
+	// that produced the signature on behalf of the user.
+	SigningAgent string
+
+	// SigningScheme defines the Notary v2 Signing Scheme used by the signature.
+	SigningScheme SigningScheme
+}
+
 // ExtendedAttribute fetches the specified Attribute with provided key from
 // signerInfo.SignedAttributes.ExtendedAttributes.
 func (signerInfo *SignerInfo) ExtendedAttribute(key string) (Attribute, error) {


### PR DESCRIPTION
### What?

Background can be checked out in https://github.com/notaryproject/notation/discussions/278

1. Created `Envelope` interface.
5. Created `internal.base.Envelope` struct to replace the orginal `SignatureEnvelope` struct. It holds the common validation logics shared by COSE/JWS.
6. Other refactoring on the algorithm and keySpec definitions.

### Test?
Added corresponding unit tests.

### Notes:
This pr depends on the https://github.com/notaryproject/notation-core-go/pull/59

Signed-off-by: Binbin Li <libinbin@microsoft.com>